### PR TITLE
Patch: 릴리즈 생성, maven 배포 워크플로 통합

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,15 @@ on:
       tag_name:
         required: true
         type: string
+    secrets:
+      MAVEN_USERNAME:
+        required: true
+      MAVEN_PASSWORD:
+        required: true
+      GPG_PASSPHRASE:
+        required: true
+      GPG_PRIVATE_KEY:
+        required: true
 
 permissions:
   contents: write
@@ -23,10 +32,12 @@ jobs:
           distribution: 'temurin' # As good as any other, see: https://github.com/actions/setup-java#supported-distributions
           java-version: '17'
           server-id: 'central'
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
+          server-username: ${{ secrets.MAVEN_USERNAME }}
+          server-password: ${{ secrets.MAVEN_PASSWORD }}
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Debug Maven Settings
+        run: cat ~/.m2/settings.xml
       - name: Set version
         run: |
           VERSION=${{ inputs.tag_name }}
@@ -35,7 +46,3 @@ jobs:
           mvn versions:commit
       - name: Build & Deploy
         run: mvn -U -B clean deploy
-        env:
-          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,54 +16,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Java
-        uses: actions/setup-java@v3 # Does also set up Maven and GPG
+        uses: actions/setup-java@v4 # Does also set up Maven and GPG
         with:
           distribution: 'temurin' # As good as any other, see: https://github.com/actions/setup-java#supported-distributions
-          java-package: 'jdk'
           java-version: '17'
-          check-latest: true
           server-id: 'central'
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: GPG_PASSPHRASE
-          cache: 'maven'
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Set version
         run: |
           VERSION=${{ inputs.tag_name }}
           VERSION=${VERSION#v}
           mvn versions:set -DnewVersion=$VERSION
           mvn versions:commit
-      - name: Write settings.xml manually
-        run: |
-          mkdir -p ~/.m2
-          cat > ~/.m2/settings.xml <<EOF
-          <settings>
-            <servers>
-              <server>
-                <id>central</id>
-                <username>${{ secrets.MAVEN_USERNAME }}</username>
-                <password>${{ secrets.MAVEN_PASSWORD }}</password>
-              </server>
-              <server>
-                <id>gpg.passphrase</id>
-                <passphrase>${{ secrets.GPG_PASSPHRASE }}</passphrase>
-              </server>
-            </servers>
-          </settings>
-          EOF
-      - name: Show settings.xml (redacted)
-        run: |
-          echo "settings.xml contents (without secrets):"
-          sed -e 's/<username>.*<\/username>/<username>***<\/username>/' \
-              -e 's/<password>.*<\/password>/<password>***<\/password>/' \
-              -e 's/<passphrase>.*<\/passphrase>/<passphrase>***<\/passphrase>/' \
-              ~/.m2/settings.xml
       - name: Build & Deploy
-        run: |
-          # -U force updates just to make sure we are using latest dependencies
-          # -B Batch mode (do not ask for user input), just in case
-          # -P activate profile
-          mvn -U -B clean deploy
+        run: mvn -U -B clean deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,5 +113,10 @@ jobs:
       - calculate_tag
       - create_github_release
     uses: version-pulse/version-pulse/.github/workflows/deploy.yml@main
+    secrets:
+      MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+      MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
     with:
       tag_name: ${{ needs.calculate_tag.outputs.new_tag }}

--- a/parser/pom.xml
+++ b/parser/pom.xml
@@ -12,7 +12,7 @@
 	<dependency>
 	    <groupId>org.springframework</groupId>
 	    <artifactId>spring-web</artifactId>
-	    <version>6.2.3</version>
+	    <version>6.2.8</version>
 	</dependency>
 	<dependency>
 		<groupId>io.github.version-pulse</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,6 @@
           </execution>
         </executions>
         <configuration>
-          <passphraseServerId>gpg.passphrase</passphraseServerId>
           <gpgArguments>
             <argument>--pinentry-mode</argument>
             <argument>loopback</argument>


### PR DESCRIPTION
### 🔎 작업 내용
main 브랜치 생성 시 릴리즈 노트를 자동으로 생성하고, maven central 에 배포하는 워크플로를 구성했습니다.


#### 세부 설명


### 🔧 추가 개선 필요 사항


### ➕ 관련 이슈
- close 