### PR TITLE
Patch: GPG 키 변경으로 인한 이전 버전 참조 제거

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Set version
         run: |
           VERSION=${{ inputs.tag_name }}

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.version-pulse</groupId>
     <artifactId>version-pulse</artifactId>
-    <version>0.1.1</version>
+    <version>0.2.4</version>
   </parent>
 
   <artifactId>app</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.github.version-pulse</groupId>
     <artifactId>version-pulse</artifactId>
-    <version>0.1.1</version>
+    <version>0.2.4</version>
   </parent>
   <artifactId>common</artifactId>
   <dependencies>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.github.version-pulse</groupId>
     <artifactId>version-pulse</artifactId>
-    <version>0.1.1</version>
+    <version>0.2.4</version>
   </parent>
   <artifactId>documentation</artifactId>
   <dependencies>

--- a/parser/pom.xml
+++ b/parser/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.version-pulse</groupId>
     <artifactId>version-pulse</artifactId>
 	<relativePath>../pom.xml</relativePath>
-	<version>0.1.1</version>  <!-- 부모에서 상속받은 버전 -->
+	<version>0.2.4</version>  <!-- 부모에서 상속받은 버전 -->
   </parent>
   <artifactId>parser</artifactId>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -2,11 +2,11 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.version-pulse</groupId>
   <artifactId>version-pulse</artifactId>
-  <version>0.1.1</version>
+  <version>0.2.4</version>
   <packaging>pom</packaging>
 
   <properties>
-    <project.version>0.1.1</project.version>
+    <project.version>0.2.4</project.version>
   </properties>
 
   <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
### 🔎 작업 내용
GPG 키 변경으로 인한 이전 버전 참조를 제거했습니다.

#### 세부 설명
이전 버전에 대해서 변경된 GPG key로 복호화를 시도하여 서명에 실패하는 문제를 해결

### 🔧 추가 개선 필요 사항


### ➕ 관련 이슈
- close 