### PR TITLE
Patch: 릴리즈 생성 후 maven 배포 워크플로 통합

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -12,6 +12,7 @@
 
   <artifactId>app</artifactId>
   <packaging>jar</packaging>
+  <name>version-pulse-app</name>
 
   <dependencies>
     <dependency>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -6,6 +6,7 @@
     <version>0.2.4</version>
   </parent>
   <artifactId>common</artifactId>
+  <name>version-pulse-common</name>
   <dependencies>
     <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
     <dependency>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -6,6 +6,7 @@
     <version>0.2.4</version>
   </parent>
   <artifactId>documentation</artifactId>
+	<name>version-pulse-documentation</name>
   <dependencies>
 	<!-- https://mvnrepository.com/artifact/org.springframework/spring-webflux -->
 	<dependency>

--- a/parser/pom.xml
+++ b/parser/pom.xml
@@ -7,6 +7,7 @@
 	<version>0.2.4</version>  <!-- 부모에서 상속받은 버전 -->
   </parent>
   <artifactId>parser</artifactId>
+	<name>version-pulse-parser</name>
   <dependencies>
 	<!-- https://mvnrepository.com/artifact/org.springframework/spring-web -->
 	<dependency>


### PR DESCRIPTION
### 🔎 작업 내용
main 브랜치에 PR 머지 시 릴리즈 생성 후 maven central 자동 배포되도록 워크플로를 통합했습니다.

#### 세부 설명
- GPG 키 변경으로 인한 이전 버전(0.1.1) 참조 제거
- 서브 모듈 project name 명시


### 🔧 추가 개선 필요 사항


### ➕ 관련 이슈
- close 